### PR TITLE
fix: 修復模式選擇按鈕文字顏色問題

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -203,6 +203,7 @@ button:active {
     padding: 12px;
     border: none;
     background: transparent;
+    color: #4b5563;
     border-radius: 8px;
     cursor: pointer;
     font-weight: 600;


### PR DESCRIPTION
問題：
- 非活動狀態的模式選擇按鈕文字為白色，在淺灰色背景上幾乎看不見
- 影響所有使用模式選擇器的工具（調酒、時間、麵包配方計算器）

修復：
- 在 .mode-btn 樣式中添加 color: #4b5563（深灰色）
- 確保非活動按鈕文字清晰可見
- 保持活動按鈕的視覺突出效果

影響範圍：
- 調酒計算器的模式切換按鈕
- 時間計算器的模式切換按鈕
- 法國麵包配方計算器的配方選擇按鈕