### PR TITLE
feat: add QR code share for cocktail and price tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.DS_Store
+*.local

--- a/app.css
+++ b/app.css
@@ -786,7 +786,7 @@ html, body {
 
 /* Section divider */
 .section-h {
-  display: flex; align-items: baseline; gap: 10px;
+  display: flex; align-items: center; gap: 10px;
   margin-bottom: 4px;
 }
 .section-h .en { font-family: var(--serif-en); font-style: italic; color: var(--text-3); font-size: 12px; }
@@ -812,3 +812,84 @@ html, body {
 }
 .glyph.lg { width: 52px; height: 52px; }
 .glyph svg { display: block; }
+
+/* ===== Share ===== */
+.btn-share {
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  width: 100%; padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font: inherit; font-size: 14px;
+  cursor: pointer;
+  transition: background .15s;
+}
+.btn-share:active { background: var(--surface-2); }
+
+.btn-share-sm {
+  display: inline-flex; align-items: center; gap: 4px;
+  margin-left: auto;
+  padding: 4px 10px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-2);
+  font: inherit; font-size: 12px;
+  cursor: pointer;
+  transition: background .15s;
+  white-space: nowrap;
+}
+.btn-share-sm:active { background: var(--surface-2); }
+
+.share-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.45);
+  display: flex; align-items: flex-end; justify-content: center;
+  z-index: 200;
+  padding-bottom: env(safe-area-inset-bottom);
+  animation: share-bg-in .2s ease;
+}
+@keyframes share-bg-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.share-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  padding: 24px 20px calc(20px + env(safe-area-inset-bottom));
+  width: 100%; max-width: 480px;
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: share-slide-up .28s cubic-bezier(.32,.72,.28,1);
+}
+@keyframes share-slide-up {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+.share-head {
+  display: flex; align-items: center; justify-content: space-between;
+  width: 100%;
+}
+.share-title {
+  font-family: var(--serif-tc); font-size: 18px; font-weight: 500;
+}
+.share-close {
+  width: 32px; height: 32px;
+  border: none; border-radius: 50%;
+  background: var(--surface-2);
+  color: var(--text-2); font-size: 14px;
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
+}
+.share-hint {
+  font-size: 13px; color: var(--text-3); align-self: flex-start;
+}
+.share-qr {
+  width: 200px; height: 200px; border-radius: 12px;
+  border: 1px solid var(--border);
+}
+.share-qr-ph {
+  width: 200px; height: 200px;
+  background: var(--surface-2); border-radius: 12px;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "widget",
       "version": "1.1.0",
       "dependencies": {
+        "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2731,6 +2732,30 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -2982,6 +3007,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001792",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
@@ -3002,6 +3036,35 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -3138,6 +3201,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3184,6 +3256,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3221,6 +3299,12 @@
       "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3529,6 +3613,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3652,6 +3749,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4037,6 +4143,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -4405,6 +4520,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -4582,12 +4709,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4653,6 +4825,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -4713,6 +4894,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -4852,6 +5050,15 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4861,6 +5068,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -5012,6 +5225,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5243,6 +5462,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -5343,6 +5576,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-comments": {
@@ -5870,6 +6115,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -6112,12 +6363,67 @@
         "workbox-core": "7.4.1"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -4,6 +4,7 @@ import { useTweaks, TweaksPanel, TweakSection, TweakColor, TweakToggle, TweakRad
 import { Splash, Home } from './home'
 import { BreadScreen, CocktailScreen, PriceScreen } from './tools'
 import { useStore } from './history'
+import { parseShareFromUrl } from './share'
 
 const TWEAK_DEFAULTS = { accent: '#C2683C', dark: false, layout: 'grid' };
 
@@ -25,7 +26,17 @@ function useIsNarrow() {
 
 export default function App() {
   const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
-  const [screen, setScreen] = useState('splash');
+  const [initialShare] = useState(() => {
+    const share = parseShareFromUrl();
+    if (share) window.history.replaceState(null, '', window.location.pathname);
+    return share;
+  });
+  const [screen, setScreen] = useState(() => {
+    const share = initialShare;
+    if (share?.t === 'cocktail') return 'cocktail';
+    if (share?.t === 'price') return 'price';
+    return 'splash';
+  });
   const [prev, setPrev] = useState(null);
   const store = useStore();
   const standalone = isStandalone();
@@ -68,10 +79,10 @@ export default function App() {
             {(screen === 'bread' || prev === 'bread') && <BreadScreen onBack={back} store={store}/>}
           </ScreenLayer>
           <ScreenLayer active={screen === 'cocktail'}>
-            {(screen === 'cocktail' || prev === 'cocktail') && <CocktailScreen onBack={back} store={store}/>}
+            {(screen === 'cocktail' || prev === 'cocktail') && <CocktailScreen onBack={back} store={store} initialShare={initialShare}/>}
           </ScreenLayer>
           <ScreenLayer active={screen === 'price'}>
-            {(screen === 'price' || prev === 'price') && <PriceScreen onBack={back} store={store}/>}
+            {(screen === 'price' || prev === 'price') && <PriceScreen onBack={back} store={store} initialShare={initialShare}/>}
           </ScreenLayer>
         </>
       )}

--- a/src/glyphs.jsx
+++ b/src/glyphs.jsx
@@ -58,5 +58,13 @@ export const Glyph = ({ size = 38, stroke = 1.4, name = 'bread', color = 'curren
       </svg>
     );
   }
+  if (name === 'share') {
+    return (
+      <svg width={s} height={s} viewBox="0 0 24 24" fill="none">
+        <path d="M12 3v11M8 7l4-4 4 4" stroke={color} strokeWidth={stroke + .2} strokeLinecap="round" strokeLinejoin="round"/>
+        <path d="M5 17v2a1 1 0 001 1h12a1 1 0 001-1v-2" stroke={color} strokeWidth={stroke} strokeLinecap="round"/>
+      </svg>
+    );
+  }
   return null;
 };

--- a/src/share.jsx
+++ b/src/share.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import QRCode from 'qrcode'
+
+function encodeShareData(data) {
+  try {
+    const json = JSON.stringify(data)
+    const b64 = btoa(unescape(encodeURIComponent(json)))
+    return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+  } catch { return '' }
+}
+
+function decodeShareData(str) {
+  try {
+    const pad = str + '=='.slice(0, (4 - str.length % 4) % 4)
+    const b64 = pad.replace(/-/g, '+').replace(/_/g, '/')
+    return JSON.parse(decodeURIComponent(escape(atob(b64))))
+  } catch { return null }
+}
+
+export function parseShareFromUrl() {
+  const m = window.location.hash.match(/[#&]share=([^&]*)/)
+  return m ? decodeShareData(m[1]) : null
+}
+
+function buildShareUrl(data) {
+  const base = window.location.origin + window.location.pathname
+  return base + '#share=' + encodeShareData(data)
+}
+
+export function ShareModal({ data, onClose }) {
+  const [qrSrc, setQrSrc] = React.useState('')
+  const [copied, setCopied] = React.useState(false)
+  const url = buildShareUrl(data)
+
+  React.useEffect(() => {
+    QRCode.toDataURL(url, { width: 220, margin: 2 }).then(setQrSrc).catch(() => {})
+  }, [url])
+
+  const copy = () => {
+    navigator.clipboard?.writeText(url).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className="share-overlay" onClick={onClose}>
+      <div className="share-card" onClick={e => e.stopPropagation()}>
+        <div className="share-head">
+          <span className="share-title">分享</span>
+          <button className="share-close" onClick={onClose}>✕</button>
+        </div>
+        <p className="share-hint">掃描 QR Code 或複製連結</p>
+        {qrSrc
+          ? <img src={qrSrc} alt="QR Code" className="share-qr"/>
+          : <div className="share-qr-ph"/>
+        }
+        <button className="btn-primary" style={{width:'100%'}} onClick={copy}>
+          {copied ? '已複製連結 ✓' : '複製連結'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/tools.jsx
+++ b/src/tools.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Glyph } from './glyphs'
 import { StarIcon } from './home'
+import { ShareModal } from './share'
 
 const RECIPES = {
   t55: { name: 'T55 長棍', short: 'T55', water: 70, salt: 2, yeast: 1,
@@ -126,7 +127,7 @@ function smartRound(v) {
   return r;
 }
 
-export function CocktailScreen({ onBack, store }) {
+export function CocktailScreen({ onBack, store, initialShare }) {
   const isFav = store.favorites.includes('cocktail');
   const onToggleFav = () => store.toggleFav('cocktail');
   const [mode, setMode] = React.useState('mixing');
@@ -150,17 +151,19 @@ export function CocktailScreen({ onBack, store }) {
           <button className={mode === 'mixing' ? 'on' : ''} onClick={() => setMode('mixing')}>調酒配方</button>
           <button className={mode === 'bac' ? 'on' : ''} onClick={() => setMode('bac')}>血液濃度</button>
         </div>
-        {mode === 'mixing' ? <CocktailMixing/> : <CocktailBAC/>}
+        {mode === 'mixing' ? <CocktailMixing initialShare={initialShare}/> : <CocktailBAC/>}
       </div>
     </div>
   );
 }
 
-function CocktailMixing() {
-  const [target, setTarget] = React.useState('9');
-  const [total, setTotal] = React.useState('250');
-  const [base, setBase] = React.useState('40');
-  const [aux, setAux] = React.useState([{ conc: '', vol: '' }]);
+function CocktailMixing({ initialShare }) {
+  const init = initialShare?.m === 'mixing' ? initialShare : null;
+  const [target, setTarget] = React.useState(init?.target ?? '9');
+  const [total, setTotal] = React.useState(init?.total ?? '250');
+  const [base, setBase] = React.useState(init?.base ?? '40');
+  const [aux, setAux] = React.useState(init?.aux ?? [{ conc: '', vol: '' }]);
+  const [showShare, setShowShare] = React.useState(false);
 
   const tConc = parseFloat(target) || 0;
   const tVol = parseFloat(total) || 0;
@@ -281,6 +284,18 @@ function CocktailMixing() {
       )}
 
       <div className="note-line">⚠️ 此計算器僅供參考。請勿酒駕，珍愛生命。</div>
+
+      {valid && (
+        <button className="btn-share" onClick={() => setShowShare(true)}>
+          <Glyph name="share" size={16}/> 分享配方
+        </button>
+      )}
+      {showShare && (
+        <ShareModal
+          data={{ t: 'cocktail', m: 'mixing', target, total, base, aux }}
+          onClose={() => setShowShare(false)}
+        />
+      )}
     </>
   );
 }
@@ -381,10 +396,23 @@ const UNIT_OPTIONS = {
 const UNIT_CONV = { ml:1, l:1000, 'fl oz':29.5735, g:1, kg:1000, '台斤':600, '市斤':500, '磅':453.592 };
 const UNIT_TYPE_LABEL = { volume:'容量類', weight:'重量類', package:'包裝類' };
 
-export function PriceScreen({ onBack, store }) {
+export function PriceScreen({ onBack, store, initialShare }) {
   const isFav = store.favorites.includes('price');
   const onToggleFav = () => store.toggleFav('price');
-  const [products, setProducts] = React.useState([]);
+  const [showShare, setShowShare] = React.useState(false);
+  const [products, setProducts] = React.useState(() => {
+    if (!initialShare?.products?.length) return [];
+    return initialShare.products.map((p, i) => {
+      const conv = UNIT_CONV[p.unit] || 1;
+      const standardQty = p.qty * conv;
+      return {
+        id: Date.now() + i, name: p.name, price: p.price, qty: p.qty, unit: p.unit, type: p.type,
+        unitPrice: p.price / p.qty,
+        standardUnitPrice: p.price / standardQty,
+        standardUnit: p.type === 'volume' ? 'ml' : p.type === 'weight' ? 'g' : p.unit,
+      };
+    });
+  });
   const [name, setName] = React.useState('');
   const [price, setPrice] = React.useState('');
   const [qty, setQty] = React.useState('');
@@ -467,7 +495,20 @@ export function PriceScreen({ onBack, store }) {
         </div>
 
         <div>
-          <div className="section-h"><span className="en">Compare</span><span className="tc">比較結果</span></div>
+          <div className="section-h">
+            <span className="en">Compare</span><span className="tc">比較結果</span>
+            {products.length > 0 && (
+              <button className="btn-share-sm" onClick={() => setShowShare(true)}>
+                <Glyph name="share" size={13}/> 分享
+              </button>
+            )}
+          </div>
+          {showShare && (
+            <ShareModal
+              data={{ t: 'price', products: products.map(p => ({ name: p.name, price: p.price, qty: p.qty, unit: p.unit, type: p.type })) }}
+              onClose={() => setShowShare(false)}
+            />
+          )}
           {products.length === 0 && (
             <div className="empty-state">
               <div className="e-en">Empty</div>


### PR DESCRIPTION
Encode current tool state into a URL hash (#share=<base64>), generate
a QR code via the qrcode library, and restore state when the share URL
is opened — no backend required.

- src/share.jsx: encode/decode helpers + ShareModal (bottom sheet)
- tools.jsx: CocktailMixing gets share button (visible when valid),
  PriceScreen gets share button in Compare section header;
  both accept initialShare to pre-fill from incoming URL
- app.jsx: parse #share= on load, skip splash and navigate directly
- glyphs.jsx: add 'share' upload icon
- app.css: share button variants + slide-up modal styles

https://claude.ai/code/session_01RgSV67AGMmkHqnBfg4CBn9