### PR TITLE
fix: 修正血液酒精濃度計算公式

### DIFF
--- a/src/tools.jsx
+++ b/src/tools.jsx
@@ -344,7 +344,7 @@ function CocktailBAC() {
   const w = parseFloat(wt) || 0;
   const widmark = gender === 'male' ? 0.68 : 0.55;
   const pure = v * p / 100 * 0.789;
-  const bac = w > 0 ? (pure / (w * widmark)) * 100 : 0;
+  const bac = w > 0 ? (pure / (w * widmark)) / 10 : 0;
 
   let level = 'safe', msg = '濃度較低，但仍建議避免駕駛';
   if (bac >= 0.05 && bac < 0.08) { level = 'warn'; msg = '已達禁止駕駛標準（0.05%）'; }


### PR DESCRIPTION
Widmark 公式結果單位為 g/kg，轉換為 % 應除以 10，
原本錯誤乘以 100，導致計算結果高出 1000 倍。

https://claude.ai/code/session_01WoPoUnA1w8mJpPrzsEdw83