### PR TITLE
fix: 優化併排輸入欄位的空間適應性

### DIFF
--- a/app.css
+++ b/app.css
@@ -490,6 +490,7 @@ html, body {
 }
 .field-label .hint {
   font-family: var(--serif-en); font-style: italic; color: var(--text-3); font-size: 11px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-left: 4px;
 }
 .input-wrap {
   position: relative;
@@ -521,6 +522,21 @@ html, body {
 .input-suffix {
   display: flex; align-items: center; padding-right: 16px;
   color: var(--text-3); font-size: 14px; font-family: var(--serif-en); font-style: italic;
+}
+
+/* Compact inputs inside two-column grid */
+.grid-2 .input-wrap input,
+.grid-2 .input-wrap select {
+  padding: 13px 12px;
+  font-size: 16px;
+}
+.grid-2 .input-wrap select {
+  padding-right: 32px;
+  background-position: right 10px center;
+}
+.grid-2 .input-suffix {
+  padding-right: 12px;
+  font-size: 13px;
 }
 
 /* Stepper preset chips */


### PR DESCRIPTION
在 grid-2 雙欄佈局中，輸入框的 padding 和字型大小縮小為適合窄欄的尺寸，
避免欄位內容顯得擁擠；同時為 hint 標籤加上 nowrap 與 ellipsis 防止溢出。

https://claude.ai/code/session_01Y5UTKnM5u4XG4HL4aJuScy