### PR TITLE
fix: 修正 grid-2 欄位溢出與 suffix 被壓縮的根本原因

### DIFF
--- a/app.css
+++ b/app.css
@@ -305,6 +305,7 @@ html, body {
   grid-template-columns: 1fr 1fr;
   gap: 12px;
 }
+.grid-2 > * { min-width: 0; }
 
 .banner {
   background: var(--surface);
@@ -521,6 +522,7 @@ html, body {
 .input-wrap input::placeholder { color: var(--text-3); }
 .input-suffix {
   display: flex; align-items: center; padding-right: 16px;
+  flex-shrink: 0;
   color: var(--text-3); font-size: 14px; font-family: var(--serif-en); font-style: italic;
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## 問題

PR #22 只修正了 padding 與字型大小，但沒有處理真正的根本原因：

1. `.grid-2` 的 grid item 預設 `min-width: auto`，在內容較寬時會撐破欄寬，導致右側欄位超出螢幕邊界
2. `.input-suffix`（`ml`、`%` 等單位標籤）沒有 `flex-shrink: 0`，在空間不足時會被 flexbox 壓縮消失

## 修正內容

- `.grid-2 > * { min-width: 0 }` — 讓 grid item 正確限縮在欄寬內
- `.input-suffix { flex-shrink: 0 }` — 確保單位標籤永遠顯示，不被壓縮

## 影響範圍

調酒計算器（調酒配方、血液濃度）的所有併排輸入欄位，以及未來任何使用 `.grid-2` 的地方。

https://claude.ai/code/session_01Y5UTKnM5u4XG4HL4aJuScy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5UTKnM5u4XG4HL4aJuScy)_