### PR TITLE
feat: 為 QR Code 分享新增標題與下載功能

### DIFF
--- a/app.css
+++ b/app.css
@@ -911,3 +911,25 @@ html, body {
   width: 200px; height: 200px;
   background: var(--surface-2); border-radius: 12px;
 }
+.share-qr-wrap {
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+}
+.share-qr-label {
+  margin: 0;
+  font-size: 14px; font-weight: 500; color: var(--text);
+  text-align: center; max-width: 200px;
+}
+.share-title-input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  font: inherit; font-size: 14px;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color .15s;
+}
+.share-title-input:focus { border-color: var(--accent); }
+.share-title-input::placeholder { color: var(--text-3); }

--- a/src/share.jsx
+++ b/src/share.jsx
@@ -27,9 +27,10 @@ function buildShareUrl(data) {
   return base + '#share=' + encodeShareData(data)
 }
 
-export function ShareModal({ data, onClose }) {
+export function ShareModal({ data, title: defaultTitle = '', onClose }) {
   const [qrSrc, setQrSrc] = React.useState('')
   const [copied, setCopied] = React.useState(false)
+  const [userTitle, setUserTitle] = React.useState(defaultTitle)
   const url = buildShareUrl(data)
 
   React.useEffect(() => {
@@ -43,6 +44,39 @@ export function ShareModal({ data, onClose }) {
     })
   }
 
+  const download = () => {
+    if (!qrSrc) return
+    const img = new Image()
+    img.onload = () => {
+      const pad = 24
+      const fontSize = 15
+      const gap = 14
+      const titleText = userTitle.trim()
+      const dlCanvas = document.createElement('canvas')
+      const titleH = titleText ? gap + fontSize + 8 : 0
+      dlCanvas.width = img.width + pad * 2
+      dlCanvas.height = img.height + pad + titleH + pad
+      const ctx = dlCanvas.getContext('2d')
+      ctx.fillStyle = '#ffffff'
+      ctx.fillRect(0, 0, dlCanvas.width, dlCanvas.height)
+      ctx.drawImage(img, pad, pad)
+      if (titleText) {
+        ctx.fillStyle = '#1a1a1a'
+        ctx.font = `600 ${fontSize}px -apple-system, "SF Pro Text", system-ui, sans-serif`
+        ctx.textAlign = 'center'
+        ctx.fillText(titleText, dlCanvas.width / 2, img.height + pad + gap + fontSize - 2)
+      }
+      dlCanvas.toBlob(blob => {
+        const a = document.createElement('a')
+        a.href = URL.createObjectURL(blob)
+        a.download = (titleText || 'qrcode') + '.png'
+        a.click()
+        URL.revokeObjectURL(a.href)
+      })
+    }
+    img.src = qrSrc
+  }
+
   return (
     <div className="share-overlay" onClick={onClose}>
       <div className="share-card" onClick={e => e.stopPropagation()}>
@@ -51,11 +85,25 @@ export function ShareModal({ data, onClose }) {
           <button className="share-close" onClick={onClose}>✕</button>
         </div>
         <p className="share-hint">掃描 QR Code 或複製連結</p>
-        {qrSrc
-          ? <img src={qrSrc} alt="QR Code" className="share-qr"/>
-          : <div className="share-qr-ph"/>
-        }
-        <button className="btn-primary" style={{width:'100%'}} onClick={copy}>
+        <div className="share-qr-wrap">
+          {qrSrc
+            ? <img src={qrSrc} alt="QR Code" className="share-qr"/>
+            : <div className="share-qr-ph"/>
+          }
+          {userTitle.trim() && <p className="share-qr-label">{userTitle.trim()}</p>}
+        </div>
+        <input
+          className="share-title-input"
+          type="text"
+          placeholder="加入標題（選填）"
+          value={userTitle}
+          onChange={e => setUserTitle(e.target.value)}
+          maxLength={40}
+        />
+        <button className="btn-primary" style={{width:'100%'}} onClick={download} disabled={!qrSrc}>
+          下載 QR Code
+        </button>
+        <button className="btn-secondary" style={{width:'100%'}} onClick={copy}>
           {copied ? '已複製連結 ✓' : '複製連結'}
         </button>
       </div>

--- a/src/tools.jsx
+++ b/src/tools.jsx
@@ -293,6 +293,7 @@ function CocktailMixing({ initialShare }) {
       {showShare && (
         <ShareModal
           data={{ t: 'cocktail', m: 'mixing', target, total, base, aux }}
+          title="調酒配方"
           onClose={() => setShowShare(false)}
         />
       )}
@@ -506,6 +507,7 @@ export function PriceScreen({ onBack, store, initialShare }) {
           {showShare && (
             <ShareModal
               data={{ t: 'price', products: products.map(p => ({ name: p.name, price: p.price, qty: p.qty, unit: p.unit, type: p.type })) }}
+              title="比價結果"
               onClose={() => setShowShare(false)}
             />
           )}


### PR DESCRIPTION
- ShareModal 新增標題輸入欄（預設帶入工具名稱）
- 標題即時顯示於 QR Code 下方作為預覽
- 新增下載按鈕，使用 canvas 將 QR Code + 標題合併為 PNG 輸出
- 調酒配方預設標題「調酒配方」，比價結果預設「比價結果」

https://claude.ai/code/session_01REQ1svXaRP8i1tV3p4N2Mu