### PR TITLE
fix: 縮減工具頁面頂部留白（70px → 16px）

### DIFF
--- a/app.css
+++ b/app.css
@@ -328,7 +328,7 @@ html, body {
 
 /* ===== Tool screen common ===== */
 .tool-head {
-  padding: max(70px, calc(env(safe-area-inset-top) + 8px)) 18px 8px;
+  padding: max(16px, calc(env(safe-area-inset-top) + 8px)) 18px 8px;
   display: flex; align-items: center; justify-content: space-between;
   gap: 8px;
 }


### PR DESCRIPTION
.tool-head 的頂部 padding 從 max(70px, ...) 改為 max(16px, ...)，
與首頁 header 的間距保持一致，避免進入工具頁面後上方留白過多。

https://claude.ai/code/session_016Kx6uB7rLZi9u6FWk67dCs