### PR TITLE
Fix: 調酒計算器輔料（aux）納入歷史紀錄儲存與還原

### DIFF
--- a/src/tools.jsx
+++ b/src/tools.jsx
@@ -185,6 +185,7 @@ function CocktailMixing({ initialShare, store, restoreEntry }) {
     if (inp.target) setTarget(inp.target);
     if (inp.total) setTotal(inp.total);
     if (inp.base) setBase(inp.base);
+    if (inp.aux) setAux(inp.aux);
   }, [restoreEntry]);
 
   const lastSavedRef = React.useRef('');
@@ -193,18 +194,19 @@ function CocktailMixing({ initialShare, store, restoreEntry }) {
     const tVol = parseFloat(total) || 0;
     const bConc = parseFloat(base) || 0;
     if (!tConc || !tVol || !bConc) return;
-    const sig = `${target}-${total}-${base}`;
+    const auxSig = aux.map(a => `${a.conc}:${a.vol}`).join(',');
+    const sig = `${target}-${total}-${base}-${auxSig}`;
     if (sig === lastSavedRef.current) return;
     const id = setTimeout(() => {
       lastSavedRef.current = sig;
       store.addHistory({
         toolId: 'cocktail', mode: '調酒配方',
         summary: `目標 ${target}% · ${total}ml · 基酒 ${base}%`,
-        inputs: { mode: 'mixing', target, total, base },
+        inputs: { mode: 'mixing', target, total, base, aux },
       });
     }, 1500);
     return () => clearTimeout(id);
-  }, [target, total, base]);
+  }, [target, total, base, aux]);
 
   const tConc = parseFloat(target) || 0;
   const tVol = parseFloat(total) || 0;


### PR DESCRIPTION
## 問題

PR #27 修復了歷史紀錄還原功能，但調酒計算器的輔料（aux）欄位遺漏了：
- 新增或修改輔料不會觸發歷史儲存
- 從歷史紀錄點回去時輔料不會被還原

## 修正內容

- `aux` 加入 `useEffect` dependency array，輔料變動時觸發儲存
- `sig`（去重用）加入 aux 序列化，避免相同輔料重複寫入
- `inputs` 加入 `aux` 欄位
- restore effect 加入 `if (inp.aux) setAux(inp.aux)`

https://claude.ai/code/session_011X5CYW3HxyZXETYMcghZJz

---
_Generated by [Claude Code](https://claude.ai/code/session_011X5CYW3HxyZXETYMcghZJz)_