### PR TITLE
修正啟動畫面在每次重整時重複出現的問題

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -35,6 +35,8 @@ export default function App() {
     const share = initialShare;
     if (share?.t === 'cocktail') return 'cocktail';
     if (share?.t === 'price') return 'price';
+    const splashShown = sessionStorage.getItem('splashShown');
+    if (splashShown) return 'home';
     return 'splash';
   });
   const [prev, setPrev] = useState(null);
@@ -47,7 +49,10 @@ export default function App() {
 
   useEffect(() => {
     if (screen === 'splash') {
-      const id = setTimeout(() => setScreen('home'), 1800);
+      const id = setTimeout(() => {
+        sessionStorage.setItem('splashShown', 'true');
+        setScreen('home');
+      }, 1800);
       return () => clearTimeout(id);
     }
   }, [screen]);


### PR DESCRIPTION
使用 sessionStorage 記錄啟動畫面是否已顯示過：
- 同一個會話中重整頁面時，啟動畫面不會重新出現
- 關閉標籤頁重新打開時，啟動畫面會正常顯示
- 保持開啟應用時的首次體驗

https://claude.ai/code/session_01U9qpEqE1he9Q7GhzeEvc9n