### PR TITLE
修正比價計算器從生活記事點選時的黑畫面問題

### DIFF
--- a/src/tools.jsx
+++ b/src/tools.jsx
@@ -526,7 +526,17 @@ export function PriceScreen({ onBack, store, initialShare, restoreEntry }) {
 
   React.useEffect(() => {
     if (!restoreEntry?.inputs?.products) return;
-    setProducts(restoreEntry.inputs.products);
+    const restoredProducts = restoreEntry.inputs.products.map((p, i) => {
+      const conv = UNIT_CONV[p.unit] || 1;
+      const standardQty = p.qty * conv;
+      return {
+        id: Date.now() + i, name: p.name, price: p.price, qty: p.qty, unit: p.unit, type: p.type,
+        unitPrice: p.price / p.qty,
+        standardUnitPrice: p.price / standardQty,
+        standardUnit: p.type === 'volume' ? 'ml' : p.type === 'weight' ? 'g' : p.unit,
+      };
+    });
+    setProducts(restoredProducts);
   }, [restoreEntry]);
 
   React.useEffect(() => {


### PR DESCRIPTION
當從生活記事點選一筆比價紀錄時，保存的產品數據缺少計算過的欄位
（id、unitPrice、standardUnitPrice、standardUnit），導致渲染時出現問題。
修正方式為在恢復時重新計算這些欄位，與初始化 initialShare 時的處理方式一致。

https://claude.ai/code/session_011Etoo1zhuksCyuCoUQJCGV