### PR TITLE
feat: Add download status feedback for QR code

### DIFF
--- a/src/share.jsx
+++ b/src/share.jsx
@@ -31,6 +31,7 @@ export function ShareModal({ data, title: defaultTitle = '', onClose }) {
   const [qrSrc, setQrSrc] = React.useState('')
   const [copied, setCopied] = React.useState(false)
   const [userTitle, setUserTitle] = React.useState(defaultTitle)
+  const [downloadStatus, setDownloadStatus] = React.useState('idle') // idle | loading | success | error
   const url = buildShareUrl(data)
 
   React.useEffect(() => {
@@ -46,33 +47,45 @@ export function ShareModal({ data, title: defaultTitle = '', onClose }) {
 
   const download = () => {
     if (!qrSrc) return
+    setDownloadStatus('loading')
     const img = new Image()
     img.onload = () => {
-      const pad = 24
-      const fontSize = 15
-      const gap = 14
-      const titleText = userTitle.trim()
-      const dlCanvas = document.createElement('canvas')
-      const titleH = titleText ? gap + fontSize + 8 : 0
-      dlCanvas.width = img.width + pad * 2
-      dlCanvas.height = img.height + pad + titleH + pad
-      const ctx = dlCanvas.getContext('2d')
-      ctx.fillStyle = '#ffffff'
-      ctx.fillRect(0, 0, dlCanvas.width, dlCanvas.height)
-      ctx.drawImage(img, pad, pad)
-      if (titleText) {
-        ctx.fillStyle = '#1a1a1a'
-        ctx.font = `600 ${fontSize}px -apple-system, "SF Pro Text", system-ui, sans-serif`
-        ctx.textAlign = 'center'
-        ctx.fillText(titleText, dlCanvas.width / 2, img.height + pad + gap + fontSize - 2)
+      try {
+        const pad = 24
+        const fontSize = 15
+        const gap = 14
+        const titleText = userTitle.trim()
+        const dlCanvas = document.createElement('canvas')
+        const titleH = titleText ? gap + fontSize + 8 : 0
+        dlCanvas.width = img.width + pad * 2
+        dlCanvas.height = img.height + pad + titleH + pad
+        const ctx = dlCanvas.getContext('2d')
+        ctx.fillStyle = '#ffffff'
+        ctx.fillRect(0, 0, dlCanvas.width, dlCanvas.height)
+        ctx.drawImage(img, pad, pad)
+        if (titleText) {
+          ctx.fillStyle = '#1a1a1a'
+          ctx.font = `600 ${fontSize}px -apple-system, "SF Pro Text", system-ui, sans-serif`
+          ctx.textAlign = 'center'
+          ctx.fillText(titleText, dlCanvas.width / 2, img.height + pad + gap + fontSize - 2)
+        }
+        dlCanvas.toBlob(blob => {
+          const a = document.createElement('a')
+          a.href = URL.createObjectURL(blob)
+          a.download = (titleText || 'qrcode') + '.png'
+          a.click()
+          URL.revokeObjectURL(a.href)
+          setDownloadStatus('success')
+          setTimeout(() => setDownloadStatus('idle'), 2000)
+        })
+      } catch (err) {
+        setDownloadStatus('error')
+        setTimeout(() => setDownloadStatus('idle'), 2000)
       }
-      dlCanvas.toBlob(blob => {
-        const a = document.createElement('a')
-        a.href = URL.createObjectURL(blob)
-        a.download = (titleText || 'qrcode') + '.png'
-        a.click()
-        URL.revokeObjectURL(a.href)
-      })
+    }
+    img.onerror = () => {
+      setDownloadStatus('error')
+      setTimeout(() => setDownloadStatus('idle'), 2000)
     }
     img.src = qrSrc
   }
@@ -100,8 +113,16 @@ export function ShareModal({ data, title: defaultTitle = '', onClose }) {
           onChange={e => setUserTitle(e.target.value)}
           maxLength={40}
         />
-        <button className="btn-primary" style={{width:'100%'}} onClick={download} disabled={!qrSrc}>
-          下載 QR Code
+        <button
+          className="btn-primary"
+          style={{width:'100%'}}
+          onClick={download}
+          disabled={!qrSrc || downloadStatus !== 'idle'}
+        >
+          {downloadStatus === 'idle' && '下載 QR Code'}
+          {downloadStatus === 'loading' && '正在下載...'}
+          {downloadStatus === 'success' && '下載完成 ✓'}
+          {downloadStatus === 'error' && '下載失敗'}
         </button>
         <button className="btn-secondary" style={{width:'100%'}} onClick={copy}>
           {copied ? '已複製連結 ✓' : '複製連結'}


### PR DESCRIPTION
- Add downloadStatus state to track download progress (idle, loading, success, error)
- Update button text and state based on download status
- Show "正在下載..." while downloading, "下載完成 ✓" on success, "下載失敗" on error
- Disable button during download and automatically reset after 2 seconds
- Add error handling for image loading failures

https://claude.ai/code/session_01TFg61yP62vDYYWvoYhmYzq