### PR TITLE
refactor: unify StarIcon, align cocktail share UI, fix desktop frame bugs

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -99,7 +99,7 @@ export default function App() {
     <div className={`stage ${!showFrame ? 'standalone' : ''}`}>
       {showFrame ? (
         <IOSDevice
-          deviceColor={t.dark ? '#1d1d1b' : '#f0ebe2'}
+          dark={t.dark}
           time={fmtTime()}
         >
           {appBody}

--- a/src/glyphs.jsx
+++ b/src/glyphs.jsx
@@ -83,3 +83,12 @@ export const Glyph = ({ size = 38, stroke = 1.4, name = 'bread', color = 'curren
   }
   return null;
 };
+
+export function StarIcon({ filled = false, size = 18 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round">
+      <path d="M12 3l2.7 5.5 6 .9-4.4 4.3 1 6-5.3-2.8L6.7 19.7l1-6L3.3 9.4l6-.9z"/>
+    </svg>
+  );
+}

--- a/src/home.jsx
+++ b/src/home.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Glyph } from './glyphs'
+import { Glyph, StarIcon } from './glyphs'
 import { relTime } from './history'
 
 export function Splash() {
@@ -36,15 +36,6 @@ export const TOOLS = [
   { id: 'price',    label: '比價計算',     en: 'Price Compare',
     desc: '不同單位、不同包裝的單價比較。', glyph: 'price' },
 ];
-
-export function StarIcon({ filled = false, size = 18 }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'}
-      stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round">
-      <path d="M12 3l2.7 5.5 6 .9-4.4 4.3 1 6-5.3-2.8L6.7 19.7l1-6L3.3 9.4l6-.9z"/>
-    </svg>
-  );
-}
 
 function ToolCard({ tool, size = 'small', extraClass = '', onPick, isFav, onToggleFav }) {
   const isLarge = size === 'large';

--- a/src/ios-frame.jsx
+++ b/src/ios-frame.jsx
@@ -153,7 +153,7 @@ export function IOSList({ header, children, dark = false }) {
   );
 }
 
-export function IOSDevice({ children, width = 402, height = 874, dark = false, title, keyboard = false }) {
+export function IOSDevice({ children, width = 402, height = 874, dark = false, title, keyboard = false, time = '9:41' }) {
   return (
     <div style={{
       width, height, borderRadius: 48, overflow: 'hidden',
@@ -167,7 +167,7 @@ export function IOSDevice({ children, width = 402, height = 874, dark = false, t
         width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
       }} />
       <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
-        <IOSStatusBar dark={dark} />
+        <IOSStatusBar dark={dark} time={time} />
       </div>
       <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
         {title !== undefined && <IOSNavBar title={title} dark={dark} />}

--- a/src/tools.jsx
+++ b/src/tools.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Glyph } from './glyphs'
-import { StarIcon } from './home'
+import { StarIcon } from './glyphs'
 import { ShareModal } from './share'
 
 const RECIPES = {
@@ -300,7 +300,14 @@ function CocktailMixing({ initialShare, store, restoreEntry, onNoteChange }) {
       </div>
 
       <div>
-        <div className="section-h"><span className="en">Recipe</span><span className="tc">配方明細</span></div>
+        <div className="section-h">
+          <span className="en">Recipe</span><span className="tc">配方明細</span>
+          {valid && (
+            <button className="btn-share-sm" onClick={() => setShowShare(true)}>
+              <Glyph name="share" size={13}/> 分享
+            </button>
+          )}
+        </div>
         <div className="liquid-list">
           <div className="liquid-row">
             <div><div className="nm">基酒</div><div className="pct">{base}% · {valid ? Math.round(fillAlc) : 0}% 杯量</div></div>
@@ -367,11 +374,6 @@ function CocktailMixing({ initialShare, store, restoreEntry, onNoteChange }) {
 
       <div className="note-line">⚠️ 此計算器僅供參考。請勿酒駕，珍愛生命。</div>
 
-      {valid && (
-        <button className="btn-share" onClick={() => setShowShare(true)}>
-          <Glyph name="share" size={16}/> 分享配方
-        </button>
-      )}
       {showShare && (
         <ShareModal
           data={{ t: 'cocktail', m: 'mixing', target, total, base, aux }}


### PR DESCRIPTION
- Move StarIcon from home.jsx to glyphs.jsx to fix backwards import dependency
- Update home.jsx and tools.jsx imports accordingly
- Move cocktail share button from bottom btn-share to btn-share-sm in section
  header, consistent with price calculator
- Fix app.jsx: was passing deviceColor (unknown prop) to IOSDevice instead
  of dark — dark mode toggle had no effect on iOS frame appearance
- Fix ios-frame.jsx: forward time prop through IOSDevice to IOSStatusBar
  so status bar shows real time instead of hardcoded 9:41

https://claude.ai/code/session_011zN5tYkbceFEyZTYU6qVcZ